### PR TITLE
feat: implementar fallback de modelos de gemini para aumentar peticiones disponibles.

### DIFF
--- a/app/Http/Controllers/FlashcardController.php
+++ b/app/Http/Controllers/FlashcardController.php
@@ -31,7 +31,13 @@ class FlashcardController extends Controller
         ]);
 
         $apiKey = env('GEMINI_API_KEY');
-        $model = 'gemini-2.5-flash-lite';
+
+        //Se definen los modelos en orden de prioridad. Si uno falla por límite, se intenta con el siguiente.
+        $models = [
+            'gemini-2.5-flash-lite',
+            'gemini-2.5-flash',
+            'gemini-3-flash-preview',
+        ];
 
         if (!$apiKey) {
             return response()->json([
@@ -57,25 +63,33 @@ class FlashcardController extends Controller
             $promptTemplate
         );
 
-        $response = Http::withHeaders([
-            'Content-Type' => 'application/json',
-            'X-goog-api-key' => $apiKey,
-        ])->post(
-            "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent",
-            [
-                'contents' => [
-                    [
-                        'parts' => [
-                            [
-                                'text' => $prompt
+        //Se intenta con cada modelo hasta que uno responda correctamente.
+        $response = null;
+        foreach ($models as $model) {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/json',
+                'X-goog-api-key' => $apiKey,
+            ])->post(
+                "https://generativelanguage.googleapis.com/v1beta/models/{$model}:generateContent",
+                [
+                    'contents' => [
+                        [
+                            'parts' => [
+                                [
+                                    'text' => $prompt
+                                ]
                             ]
                         ]
                     ]
                 ]
-            ]
-        );
+            );
 
-        if (!$response->successful()) {
+            if ($response->successful()) {
+                break;
+            }
+        }
+
+        if (!$response || !$response->successful()) {
             return response()->json([
                 'ok' => false,
                 'message' => 'Error al consumir la API generativa.',


### PR DESCRIPTION
Se implementa fallback automático entre modelos de Gemini cuando se alcanza el límite de peticiones diarias.

gemini-2.5-flash-lite (primero, más rápido)
gemini-2.5-flash (segundo, si el primero falla)
gemini-3-flash-preview (tercero, si los anteriores fallan)